### PR TITLE
Adds version subcommand

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Get the TAG version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Updates the version file to use it from the CLI
+        run: echo ${{ steps.get_version.outputs.VERSION }} > src/main/resources/version.txt
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
@@ -31,4 +33,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          files: ./build/distributions/mod-connect.zip
+          files: ./build/distributions/mod-connect-${{ steps.get_version.outputs.VERSION }}.zip

--- a/src/main/java/io/moderne/connect/commands/Connect.java
+++ b/src/main/java/io/moderne/connect/commands/Connect.java
@@ -24,7 +24,8 @@ import picocli.CommandLine.HelpCommand;
         subcommands = {
                 HelpCommand.class,
                 Jenkins.class,
-                GitHub.class
+                GitHub.class,
+                Version.class
         })
 public class Connect {
 

--- a/src/main/java/io/moderne/connect/commands/Version.java
+++ b/src/main/java/io/moderne/connect/commands/Version.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.moderne.connect.commands;
+
+import picocli.CommandLine;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "version", description = "Prints the mod-connect version")
+public class Version implements Callable<Integer> {
+
+    @CommandLine.Spec
+    protected CommandLine.Model.CommandSpec commandSpec;
+
+    @Override
+    public Integer call() throws Exception {
+        try(InputStream is = this.getClass().getClassLoader().getResourceAsStream("version.txt")){
+            if (is == null) {
+                System.out.println("[ERROR] Version not found");
+                return 1;
+            }
+            String version = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8)).readLine();
+            commandSpec.commandLine().getOut().println(version);
+        }
+        return 0;
+    }
+}

--- a/src/main/resources/version.txt
+++ b/src/main/resources/version.txt
@@ -1,0 +1,1 @@
+development

--- a/src/test/java/io/moderne/connect/commands/VersionTest.java
+++ b/src/test/java/io/moderne/connect/commands/VersionTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.moderne.connect.commands;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VersionTest {
+
+    @Test
+    void printsVersion() {
+        CommandLine cmd = new CommandLine(new Connect());
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        cmd.setErr(new PrintWriter(sw));
+        assertEquals(0, cmd.execute("version"));
+        assertEquals("development\n", sw.toString());
+    }
+}


### PR DESCRIPTION
## What's changed?
Adds the version as a subcommand

## What's your motivation?
Having traceability of errors after release.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
