### PR TITLE
added CDATA to support xml entities

### DIFF
--- a/src/main/resources/cli/jenkins/flow_definition.xml.template
+++ b/src/main/resources/cli/jenkins/flow_definition.xml.template
@@ -30,9 +30,9 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@%s">
-        <script>
-        %s
-        </script>
+        <script><![CDATA[
+%s
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-agent.xml
+++ b/src/test/jenkins/config-agent.xml
@@ -32,7 +32,7 @@
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
         <script><![CDATA[
         pipeline {
-            agent any
+            agent { label 'os=windows && !reserved' }
             options {
                 timeout(time: 1, unit: 'HOURS')
                 disableConcurrentBuilds(abortPrevious: true)
@@ -56,11 +56,9 @@
                     }
                     steps {
                         sh './mod version'
-
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactCreds', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
-                            sh './mod publish --path . --publishUrl https://artifactory.moderne.ninja/artifactory/moderne-ingest --publishUser ${ARTIFACTS_PUBLISH_CRED_USR} --publishPwd ${ARTIFACTS_PUBLISH_CRED_PWD} --desiredStyle="" --additionalBuildArgs="" --skipSSL="false" --verbose --mvnPluginVersion 5.0.2'
+                            sh './mod publish --path . --publishUrl https://artifactory.moderne.ninja/artifactory/moderne-ingest --publishUser ${ARTIFACTS_PUBLISH_CRED_USR} --publishPwd ${ARTIFACTS_PUBLISH_CRED_PWD} --desiredStyle="" --additionalBuildArgs="" --skipSSL="false" --verbose'
                         }
-
                     }
                 }
             }

--- a/src/test/jenkins/config-defaultJdk.xml
+++ b/src/test/jenkins/config-defaultJdk.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -69,7 +69,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-defaultJdk.xml
+++ b/src/test/jenkins/config-defaultJdk.xml
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }

--- a/src/test/jenkins/config-detect-java-with-supported.xml
+++ b/src/test/jenkins/config-detect-java-with-supported.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -69,7 +69,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-detect-java.xml
+++ b/src/test/jenkins/config-detect-java.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -69,7 +69,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-with-custom-url-creds.xml
+++ b/src/test/jenkins/config-with-custom-url-creds.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -47,7 +47,7 @@
                 stage('Download CLI') {
                     steps {
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'downloadCreds', usernameVariable: 'CLI_DOWNLOAD_CRED_USR', passwordVariable: 'CLI_DOWNLOAD_CRED_PWD']]) {
-                            sh "curl --user ${CLI_DOWNLOAD_CRED_USR}:${CLI_DOWNLOAD_CRED_PWD} --request GET https://acme.com/moderne-cli &gt; mod"
+                            sh "curl --user ${CLI_DOWNLOAD_CRED_USR}:${CLI_DOWNLOAD_CRED_PWD} --request GET https://acme.com/moderne-cli > mod"
                             sh "chmod 755 mod"
                         }
                     }
@@ -70,7 +70,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-with-custom-url.xml
+++ b/src/test/jenkins/config-with-custom-url.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://acme.com/moderne-cli &gt; mod"
+                        sh "curl --request GET https://acme.com/moderne-cli > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -68,7 +68,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-with-gradle-plugin.xml
+++ b/src/test/jenkins/config-with-gradle-plugin.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -70,7 +70,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-with-maven-settings.xml
+++ b/src/test/jenkins/config-with-maven-settings.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -70,7 +70,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-with-skipSSL.xml
+++ b/src/test/jenkins/config-with-skipSSL.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -68,7 +68,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-without-download.xml
+++ b/src/test/jenkins/config-without-download.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -62,7 +62,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config-without-java.xml
+++ b/src/test/jenkins/config-without-java.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -65,7 +65,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -68,7 +68,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>

--- a/src/test/jenkins/rewrite-java-migration-config.xml
+++ b/src/test/jenkins/rewrite-java-migration-config.xml
@@ -30,7 +30,7 @@
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
     <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
-        <script>
+        <script><![CDATA[
         pipeline {
             agent any
             options {
@@ -46,7 +46,7 @@
                 }
                 stage('Download CLI') {
                     steps {
-                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 &gt; mod"
+                        sh "curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v0.2.43/moderne-cli-linux-v0.2.43 > mod"
                         sh "chmod 755 mod"
                     }
                 }
@@ -69,7 +69,7 @@
                 }
             }
         }
-        </script>
+        ]]></script>
         <sandbox>true</sandbox>
     </definition>
     <triggers/>


### PR DESCRIPTION
## What's changed?
Added CDATA block in <script> to allow for xml entities and special characters in the custom parameters

## What's your motivation?
Without it, complex agents (like `{ label 'os=windows && !reserved' }`) do not work.

## Anyone you would like to review specifically?
@timtebeek @shanman190 

## Have you considered any alternatives or workarounds?
Encoding the special characters might be another solution, but adding a CDATA block seems more robust if it does not interfere with Jenkins (which doesn't seem to be the case, manually tested)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases