### PR TITLE
Use powershell steps when platform has been set to Windows

### DIFF
--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -609,11 +609,11 @@ public class Jenkins implements Callable<Integer> {
         }
         final String downloadCommand;
         if (StringUtils.isBlank(downloadCLICreds)) {
-            downloadCommand = PLATFORM_WINDOWS.equals(platform) ?
+            downloadCommand = isWindowsPlatform() ?
                     Templates.DOWNLOAD_WITHOUT_CREDENTIALS_WINDOWS.format(downloadURL) :
                     Templates.DOWNLOAD_WITHOUT_CREDENTIALS.format(downloadURL);
         } else {
-            downloadCommand = PLATFORM_WINDOWS.equals(platform) ?
+            downloadCommand = isWindowsPlatform() ?
                     Templates.DOWNLOAD_WITH_CREDENTIALS_WINDOWS.format(downloadURL) :
                     Templates.DOWNLOAD_WITH_CREDENTIALS.format(downloadCLICreds, downloadURL);
         }
@@ -668,7 +668,7 @@ public class Jenkins implements Callable<Integer> {
     }
 
     private String createShell(String repoStyle, String repoBuildAction, boolean prependJavaVersion) {
-        boolean isWindowsPlatform = PLATFORM_WINDOWS.equals(platform);
+        boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI) {
             command += isWindowsPlatform ? ".\\\\" : "./";
@@ -756,4 +756,7 @@ public class Jenkins implements Callable<Integer> {
                 pipeline);
     }
 
+    private boolean isWindowsPlatform() {
+        return PLATFORM_WINDOWS.equals(platform);
+    }
 }

--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -306,6 +306,7 @@ public class Jenkins implements Callable<Integer> {
 
     static final String JENKINS_CRUMB_HEADER = "Jenkins-Crumb";
 
+    private static final String PLATFORM_WINDOWS = "windows";
     private static final String CLOUDBEES_FOLDER_PLUGIN = "cloudbees-folder";
     private static final String WORKFLOW_JOB_PLUGIN = "workflow-job";
     private static final String PIPELINE_MODEL_DEFINITION_PLUGIN = "pipeline-model-definition";
@@ -608,11 +609,11 @@ public class Jenkins implements Callable<Integer> {
         }
         final String downloadCommand;
         if (StringUtils.isBlank(downloadCLICreds)) {
-            downloadCommand = "windows".equals(platform) ?
+            downloadCommand = PLATFORM_WINDOWS.equals(platform) ?
                     Templates.DOWNLOAD_WITHOUT_CREDENTIALS_WINDOWS.format(downloadURL) :
                     Templates.DOWNLOAD_WITHOUT_CREDENTIALS.format(downloadURL);
         } else {
-            downloadCommand = "windows".equals(platform) ?
+            downloadCommand = PLATFORM_WINDOWS.equals(platform) ?
                     Templates.DOWNLOAD_WITH_CREDENTIALS_WINDOWS.format(downloadURL) :
                     Templates.DOWNLOAD_WITH_CREDENTIALS.format(downloadCLICreds, downloadURL);
         }
@@ -667,7 +668,7 @@ public class Jenkins implements Callable<Integer> {
     }
 
     private String createShell(String repoStyle, String repoBuildAction, boolean prependJavaVersion) {
-        boolean isWindowsPlatform = "windows".equals(platform);
+        boolean isWindowsPlatform = PLATFORM_WINDOWS.equals(platform);
         String command = "";
         if (downloadCLI) {
             command += isWindowsPlatform ? ".\\\\" : "./";

--- a/src/main/resources/cli/jenkins/pipeline_credentials_windows.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline_credentials_windows.groovy.template
@@ -1,0 +1,3 @@
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '%s', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
+                    powershell '%s'
+                }

--- a/src/main/resources/cli/jenkins/pipeline_download_creds_windows.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline_download_creds_windows.groovy.template
@@ -1,0 +1,7 @@
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '%s', usernameVariable: 'CLI_DOWNLOAD_CRED_USR', passwordVariable: 'CLI_DOWNLOAD_CRED_PWD']]) {
+                    powershell '''
+                    $wc = New-Object System.Net.WebClient
+                    $wc.Credentials = new NetworkCredentials($env:CLI_DOWNLOAD_CRED_USR, $env:CLI_DOWNLOAD_CRED_PWD)
+                    $wc.DownloadFile("%s", "mod.exe")
+                    '''
+                }

--- a/src/main/resources/cli/jenkins/pipeline_download_windows.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline_download_windows.groovy.template
@@ -1,0 +1,4 @@
+                powershell '''
+                $wc = New-Object System.Net.WebClient
+                $wc.DownloadFile("%s", "mod.exe")
+                '''

--- a/src/test/jenkins/config-windows.xml
+++ b/src/test/jenkins/config-windows.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
+    <actions>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
+            <jobProperties/>
+            <triggers>
+                <string>hudson.triggers.TimerTrigger</string>
+            </triggers>
+            <parameters/>
+            <options/>
+        </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+    </actions>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <jenkins.model.BuildDiscarderProperty>
+            <strategy class="hudson.tasks.LogRotator">
+                <daysToKeep>-1</daysToKeep>
+                <numToKeep>3</numToKeep>
+                <artifactDaysToKeep>-1</artifactDaysToKeep>
+                <artifactNumToKeep>-1</artifactNumToKeep>
+            </strategy>
+        </jenkins.model.BuildDiscarderProperty>
+        <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+            <triggers>
+                <hudson.triggers.TimerTrigger>
+                    <spec>H H * * *</spec>
+                </hudson.triggers.TimerTrigger>
+            </triggers>
+        </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+    </properties>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
+        <script><![CDATA[
+        pipeline {
+            agent any
+            options {
+                timeout(time: 1, unit: 'HOURS')
+                disableConcurrentBuilds(abortPrevious: true)
+            }
+            triggers { cron('H H * * *') }
+            stages {
+                stage('Checkout') {
+                    steps {
+                        git (url: 'https://github.com/openrewrite/rewrite-spring.git', branch: 'main', credentialsId: 'myGitCreds')
+                    }
+                }
+
+                stage('Download CLI') {
+                    steps {
+                        powershell '''
+                        $wc = New-Object System.Net.WebClient
+                        $wc.DownloadFile("https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-windows/v0.2.43/moderne-cli-windows-v0.2.43", "mod.exe")
+                        '''
+                    }
+                }
+
+
+                stage('Publish') {
+                    tools {
+                        jdk 'java11'
+                    }
+                    steps {
+                        powershell '.\\mod.exe version'
+                        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactCreds', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
+                            powershell '.\\mod.exe publish --path . --publishUrl https://artifactory.moderne.ninja/artifactory/moderne-ingest --publishUser $env:ARTIFACTS_PUBLISH_CRED_USR --publishPwd $env:ARTIFACTS_PUBLISH_CRED_PWD --desiredStyle="" --additionalBuildArgs="" --skipSSL="false" --verbose'
+                        }
+                    }
+                }
+
+            }
+            post {
+                always {
+                    cleanWs()
+                }
+            }
+        }
+        ]]></script>
+        <sandbox>true</sandbox>
+    </definition>
+    <triggers/>
+    <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
## What's changed?
Finishing out support for running publishing steps from a Windows agent. In particular, the Jenkins `sh` step relies upon `nohup` which isn't available. As such on Windows, we should use the `powershell` step instead.

## Anyone you would like to review specifically?
@joanvr

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
