### PR TITLE
pinned git-client version to 4.4.0

### DIFF
--- a/src/test/jenkins/Dockerfile
+++ b/src/test/jenkins/Dockerfile
@@ -7,6 +7,7 @@ RUN jenkins-plugin-cli --plugins \
     cloudbees-folder:6.815.v0dd5a_cb_40e0e \
     configuration-as-code:1647.ve39ca_b_829b_42 \
     git:5.1.0 \
+    git-client:4.4.0 \
     gradle:2.8 \
     jdk-tool:66.vd8fa_64ee91b_d \
     pipeline-model-definition:2.2121.vd87fb_6536d1e \


### PR DESCRIPTION
## What's changed?
Added explicitly the git-client dependency to the Dockerfile used in the integration tests.

## What's your motivation?
New git-client released version (4.5.0), has a newer dependency on configuration-as-code that we had pinned. So, if we pin to 4.4.0, all other dependencies are good, and we do not need to update all test outputs.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
