### PR TITLE
archiveArtifacts artifacts: '**/build.log'

### DIFF
--- a/src/main/resources/cli/jenkins/freestyle_job.xml.template
+++ b/src/main/resources/cli/jenkins/freestyle_job.xml.template
@@ -29,7 +29,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>.moderne/build/**/build.log</artifacts>
+      <artifacts>**/build.log</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/src/main/resources/cli/jenkins/pipeline.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline.groovy.template
@@ -12,7 +12,7 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: '.moderne/build/**/build.log'
+            archiveArtifacts artifacts: '**/build.log'
             cleanWs()
         }
     }

--- a/src/test/jenkins/config-agent.xml
+++ b/src/test/jenkins/config-agent.xml
@@ -56,7 +56,7 @@
             }
             post {
                 always {
-                    archiveArtifacts artifacts: '.moderne/build/**/build.log'
+                    archiveArtifacts artifacts: '**/build.log'
                     cleanWs()
                 }
             }

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -86,7 +86,7 @@ echo "ingest.gradle" >> .git/info/exclude;
     </builders>
     <publishers>
         <hudson.tasks.ArtifactArchiver>
-            <artifacts>.moderne/build/**/build.log</artifacts>
+            <artifacts>**/build.log</artifacts>
             <allowEmptyArchive>false</allowEmptyArchive>
             <onlyIfSuccessful>false</onlyIfSuccessful>
             <fingerprint>false</fingerprint>

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -56,7 +56,7 @@
             }
             post {
                 always {
-                    archiveArtifacts artifacts: '.moderne/build/**/build.log'
+                    archiveArtifacts artifacts: '**/build.log'
                     cleanWs()
                 }
             }

--- a/src/test/jenkins/rewrite-java-migration-config.xml
+++ b/src/test/jenkins/rewrite-java-migration-config.xml
@@ -59,7 +59,7 @@
             }
             post {
                 always {
-                    archiveArtifacts artifacts: '.moderne/build/**/build.log'
+                    archiveArtifacts artifacts: '**/build.log'
                     cleanWs()
                 }
             }


### PR DESCRIPTION
After seeing failures due to
```
Archiving artifacts
‘.moderne/build/**/build.log’ doesn’t match anything, but ‘**/build.log’ does. Perhaps that’s what you mean?
Error when executing always post condition:
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: ad746932-9e4f-4851-9929-05cbf0b3209d
hudson.AbortException: No artifacts found that match the file pattern ".moderne/build/**/build.log". Configuration error?
```
https://jenkins.moderne.ninja/view/Maven/job/cli-ingest/job/apache_maven-ejb-plugin_master/lastFailedBuild/console

Could have been temporary due to the normalization issues, but at least this way it should still match.