### PR TITLE
fix: GitLab pipeline username/password prefixed with $ in createConfigArtifactsCommand

### DIFF
--- a/src/main/java/io/moderne/connect/commands/GitLab.java
+++ b/src/main/java/io/moderne/connect/commands/GitLab.java
@@ -437,8 +437,8 @@ public class GitLab implements Callable<Integer> {
         }
         String args = String.format("config artifacts %s--user=%s --password=%s %s",
                 skipSSL ? "--skipSSL " : "",
-                variable(publishUserSecretName),
-                variable(publishPwdSecretName),
+                publishUserSecretName,
+                publishPwdSecretName,
                 publishUrl
         );
         return modCommand(args);
@@ -451,7 +451,7 @@ public class GitLab implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String token = tenant.moderneToken;
         if (tenant.moderneTokenSecret != null) {
-            token = variable(tenant.moderneTokenSecret);
+            token = tenant.moderneTokenSecret;
         }
         if (token == null) {
             token = isWindowsPlatform ? "$env:MODERNE_TOKEN" : "${MODERNE_TOKEN}";

--- a/src/test/java/io/moderne/connect/commands/GitlabTest.java
+++ b/src/test/java/io/moderne/connect/commands/GitlabTest.java
@@ -147,7 +147,7 @@ class GitlabTest {
             gitlab.publishUrl = "https://my.artifactory/moderne-ingest";
             gitlab.publishPwdSecretName = "PUBLISH_SECRET";
             gitlab.publishUserSecretName = "PUBLISH_USER";
-            assertBuildSteps(".\\\\mod.exe config artifacts --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+            assertBuildSteps(".\\\\mod.exe config artifacts --user=PUBLISH_USER --password=PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     ".\\\\mod.exe build $REPO_PATH --no-download --active-style some-style --additional-build-args \"--magic\"",
                     ".\\\\mod.exe publish $REPO_PATH");
         }
@@ -159,7 +159,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             gitlab.skipSSL = true;
             assertBuildSteps(
-                    "./mod config artifacts --skipSSL --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config artifacts --skipSSL --user=PUBLISH_USER --password=PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download --active-style some-style --additional-build-args \"--magic\"",
                     "./mod publish $REPO_PATH"
             );
@@ -175,7 +175,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
                     "./mod config moderne --token=modToken https://app.moderne.io",
-                    "./mod config artifacts --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config artifacts --user=PUBLISH_USER --password=PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download --active-style some-style --additional-build-args \"--magic\"",
                     "./mod publish $REPO_PATH"
             );
@@ -190,7 +190,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
                     "./mod config moderne --token=${MODERNE_TOKEN} https://app.moderne.io",
-                    "./mod config artifacts --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config artifacts --user=PUBLISH_USER --password=PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download --active-style some-style --additional-build-args \"--magic\"",
                     "./mod publish $REPO_PATH"
             );
@@ -205,8 +205,8 @@ class GitlabTest {
             gitlab.publishPwdSecretName = "PUBLISH_SECRET";
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
-                    "./mod config moderne --token=$SECRET https://app.moderne.io",
-                    "./mod config artifacts --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config moderne --token=SECRET https://app.moderne.io",
+                    "./mod config artifacts --user=PUBLISH_USER --password=PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download --active-style some-style --additional-build-args \"--magic\"",
                     "./mod publish $REPO_PATH"
             );


### PR DESCRIPTION
## What's changed?
Removing the `variable` call on publishUserSecretName and publishPwdSecretName in the GitLab pipeline generation as these values are being re-interpreted as environment variables. 

## What's your motivation?
Forked the gitlab starter repo https://gitlab.com/moderneinc/moderne-gitlab-ingest and provided the environment variables. 
You can see the username and password are being prefixed with `$` in the generated pipeline and interpreted as environment variables. 
 ![Screenshot 2023-09-19 at 4 28 43 PM](https://github.com/moderneinc/mod-connect/assets/882752/30e3c2ef-e19e-46cb-b43b-e0e6c8d9a73d)

![Screenshot 2023-09-19 at 4 28 58 PM](https://github.com/moderneinc/mod-connect/assets/882752/02326916-0bf4-4336-b495-aa2b2cbca4f4)

```yaml
./mod-connect/bin/mod-connect gitlab \
      --fromCsv repositories.csv \
      --publishUrl $PUBLISH_URL \
      --publishUserSecretName $PUBLISH_USER_SECRET \
      --publishPwdSecretName $PUBLISH_PASSWORD_SECRET \
      --cliVersion $MOD_CLI_VERSION \
      --downloadCLIUrl $MOD_CLI_DOWNLOAD_URL
``` 

## Anything in particular you'd like reviewers to focus on?
Wasn't sure about the `tenant.moderneTokenSecret` option but I think it also doesn't need to be passed through the `variable`

## Anyone you would like to review specifically?
@timtebeek @pstreef 

## Have you considered any alternatives or workarounds?
Not that I'm aware of.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
