### PR TITLE
Drop ::set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get the TAG version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Updates the version file to use it from the CLI
         run: echo ${{ steps.get_version.outputs.VERSION }} > src/main/resources/version.txt
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
As per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
