### PR TITLE
adding optional workspace cleanup.

### DIFF
--- a/src/main/resources/cli/jenkins/freestyle_cleanup.xml.template
+++ b/src/main/resources/cli/jenkins/freestyle_cleanup.xml.template
@@ -1,0 +1,14 @@
+    <hudson.plugins.ws__cleanup.WsCleanup plugin="ws-cleanup@%s">
+      <patterns class="empty-list"/>
+      <deleteDirs>false</deleteDirs>
+      <skipWhenFailed>false</skipWhenFailed>
+      <cleanWhenSuccess>true</cleanWhenSuccess>
+      <cleanWhenUnstable>true</cleanWhenUnstable>
+      <cleanWhenFailure>true</cleanWhenFailure>
+      <cleanWhenNotBuilt>true</cleanWhenNotBuilt>
+      <cleanWhenAborted>true</cleanWhenAborted>
+      <notFailBuild>false</notFailBuild>
+      <cleanupMatrixParent>false</cleanupMatrixParent>
+      <externalDelete></externalDelete>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.WsCleanup>

--- a/src/main/resources/cli/jenkins/freestyle_job.xml.template
+++ b/src/main/resources/cli/jenkins/freestyle_job.xml.template
@@ -37,20 +37,7 @@
       <caseSensitive>true</caseSensitive>
       <followSymlinks>false</followSymlinks>
     </hudson.tasks.ArtifactArchiver>
-    <hudson.plugins.ws__cleanup.WsCleanup plugin="ws-cleanup@%s">
-      <patterns class="empty-list"/>
-      <deleteDirs>false</deleteDirs>
-      <skipWhenFailed>false</skipWhenFailed>
-      <cleanWhenSuccess>true</cleanWhenSuccess>
-      <cleanWhenUnstable>true</cleanWhenUnstable>
-      <cleanWhenFailure>true</cleanWhenFailure>
-      <cleanWhenNotBuilt>true</cleanWhenNotBuilt>
-      <cleanWhenAborted>true</cleanWhenAborted>
-      <notFailBuild>false</notFailBuild>
-      <cleanupMatrixParent>false</cleanupMatrixParent>
-      <externalDelete></externalDelete>
-      <disableDeferredWipeout>false</disableDeferredWipeout>
-    </hudson.plugins.ws__cleanup.WsCleanup>
+%s
   </publishers>
   <buildWrappers>
 %s

--- a/src/main/resources/cli/jenkins/pipeline.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline.groovy.template
@@ -13,7 +13,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: '.moderne/build/**/build.log'
-            cleanWs()
+            %s
         }
     }
 }

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -1,0 +1,128 @@
+<?xml version="1.1" encoding="UTF-8"?><project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <jenkins.model.BuildDiscarderProperty>
+            <strategy class="hudson.tasks.LogRotator">
+                <daysToKeep>-1</daysToKeep>
+                <numToKeep>3</numToKeep>
+                <artifactDaysToKeep>-1</artifactDaysToKeep>
+                <artifactNumToKeep>3</artifactNumToKeep>
+            </strategy>
+        </jenkins.model.BuildDiscarderProperty>
+    </properties>
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@5.1.0">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+                <url>https://github.com/openrewrite/rewrite-spring.git</url>
+                <credentialsId>myGitCreds</credentialsId>
+            </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+            <hudson.plugins.git.BranchSpec>
+                <name>*/main</name>
+            </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions/>
+    </scm>
+
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers>
+        <hudson.triggers.TimerTrigger>
+            <spec>H H * * *</spec>
+        </hudson.triggers.TimerTrigger>
+    </triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v1.0.3/moderne-cli-linux-v1.0.3 --fail -o mod;
+                chmod 755 mod;</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>./mod config moderne --token=${MODERNE_TOKEN} https://app.moderne.io</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>./mod config artifacts --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command><![CDATA[
+echo "
+  task modBuild(type:Exec) {
+    workingDir '.'
+    commandLine './mod', 'build', '.', '--no-download', '--maven-settings', '${MODERNE_MVN_SETTINGS_XML}'
+  }
+" > ingest.gradle;
+echo "ingest.gradle" >> .git/info/exclude;
+      ]]></command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.plugins.gradle.Gradle plugin="gradle@2.8">
+            <switches/>
+            <tasks>modBuild</tasks>
+            <rootBuildScriptDir/>
+            <buildFile>ingest.gradle</buildFile>
+            <gradleName>gradle</gradleName>
+            <useWrapper>false</useWrapper>
+            <makeExecutable>false</makeExecutable>
+            <useWorkspaceAsHome>false</useWorkspaceAsHome>
+            <wrapperLocation/>
+            <passAllAsSystemProperties>false</passAllAsSystemProperties>
+            <projectProperties/>
+            <passAllAsProjectProperties>false</passAllAsProjectProperties>
+        </hudson.plugins.gradle.Gradle>
+
+        <hudson.tasks.Shell>
+            <command>./mod publish .</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+
+    </builders>
+    <publishers>
+        <hudson.tasks.ArtifactArchiver>
+            <artifacts>.moderne/build/**/build.log</artifacts>
+            <allowEmptyArchive>false</allowEmptyArchive>
+            <onlyIfSuccessful>false</onlyIfSuccessful>
+            <fingerprint>false</fingerprint>
+            <defaultExcludes>true</defaultExcludes>
+            <caseSensitive>true</caseSensitive>
+            <followSymlinks>false</followSymlinks>
+        </hudson.tasks.ArtifactArchiver>
+    </publishers>
+    <buildWrappers>
+        <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@631.v861c06d062b_4">
+            <bindings>
+                <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+                    <credentialsId>artifactCreds</credentialsId>
+                    <usernameVariable>ARTIFACTS_PUBLISH_CRED_USR</usernameVariable>
+                    <passwordVariable>ARTIFACTS_PUBLISH_CRED_PWD</passwordVariable>
+                </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+                <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+                    <credentialsId>modToken</credentialsId>
+                    <variable>MODERNE_TOKEN</variable>
+                </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+
+            </bindings>
+        </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
+
+        <org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper plugin="config-file-provider@953.v0432a_802e4d2">
+            <managedFiles>
+                <org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
+                    <fileId>maven_settings</fileId>
+                    <replaceTokens>false</replaceTokens>
+                    <variable>MODERNE_MVN_SETTINGS_XML</variable>
+                </org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
+            </managedFiles>
+        </org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper>
+
+    </buildWrappers>
+</project>

--- a/src/test/jenkins/config-no-cleanup.xml
+++ b/src/test/jenkins/config-no-cleanup.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
+    <actions>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
+            <jobProperties/>
+            <triggers>
+                <string>hudson.triggers.TimerTrigger</string>
+            </triggers>
+            <parameters/>
+            <options/>
+        </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+    </actions>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <jenkins.model.BuildDiscarderProperty>
+            <strategy class="hudson.tasks.LogRotator">
+                <daysToKeep>-1</daysToKeep>
+                <numToKeep>3</numToKeep>
+                <artifactDaysToKeep>-1</artifactDaysToKeep>
+                <artifactNumToKeep>3</artifactNumToKeep>
+            </strategy>
+        </jenkins.model.BuildDiscarderProperty>
+        <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+            <triggers>
+                <hudson.triggers.TimerTrigger>
+                    <spec>H H * * *</spec>
+                </hudson.triggers.TimerTrigger>
+            </triggers>
+        </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+    </properties>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
+        <script><![CDATA[
+        pipeline {
+            agent any
+            options {
+                timeout(time: 1, unit: 'HOURS')
+                disableConcurrentBuilds(abortPrevious: true)
+            }
+            triggers { cron('H H * * *') }
+            stages {
+                stage('Checkout') {
+                    steps {
+                        git (url: 'https://github.com/openrewrite/rewrite-spring.git', branch: 'main', credentialsId: 'myGitCreds')
+                    }
+                }
+                stage('Publish') {
+                    steps {
+                        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactCreds', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
+                            sh 'mod config artifacts --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest'
+                        }
+                        sh 'mod build . --no-download'
+                        sh 'mod publish .'
+                    }
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: '.moderne/build/**/build.log'
+                }
+            }
+        }
+        ]]></script>
+        <sandbox>true</sandbox>
+    </definition>
+    <triggers/>
+    <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
## What's changed?
Workspace cleanup in Jenkins is now optional (through flag --workspaceCleanup

## What's your motivation?
To choose between cleanup some space and to have logs and artifacts on the workspace available after building (for urls printed by mod-cli to keep working)

## Anyone you would like to review specifically?
<!-- @mention them here -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
