### PR TITLE
moving gradle/maven plugin versions and mirrorUrl to configs

### DIFF
--- a/src/main/resources/cli/jenkins/pipeline_stage_publish.groovy.template
+++ b/src/main/resources/cli/jenkins/pipeline_stage_publish.groovy.template
@@ -1,7 +1,7 @@
         stage('Publish') {
 %s
             steps {
-%s%s
+%s%s%s%s
 %s
 %s
             }

--- a/src/test/java/io/moderne/connect/commands/JenkinsIntegTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsIntegTest.java
@@ -104,6 +104,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup",
                 "--verbose");
         assertEquals(0, result);
@@ -299,6 +302,9 @@ class JenkinsIntegTest {
                     "--moderneToken=" + MODERNE_TOKEN,
                     "--jobType", "FREESTYLE",
                     "--workspaceCleanup",
+                    "--gradlePluginVersion", "2.2.2",
+                    "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                    "--mvnPluginVersion", "2.4.2",
                     "--verbose");
             assertEquals(0, result);
 
@@ -309,6 +315,11 @@ class JenkinsIntegTest {
             assertTrue(response.isSuccess(), "Failed to get job config.xml: " + response.getStatusText());
             String expectedJob = new String(Files.readAllBytes(new File("src/test/jenkins/config-freestyle-gradle.xml").toPath()));
             assertThat(response.getBody()).isEqualToIgnoringWhitespace(expectedJob);
+
+            HttpResponse<String> responseMaven = Unirest.get(jenkinsHost + "/job/freestyle/job/openrewrite_rewrite-maven-plugin_main/config.xml").asString();
+            assertTrue(response.isSuccess(), "Failed to get job config.xml: " + response.getStatusText());
+            String expectedJobMaven = new String(Files.readAllBytes(new File("src/test/jenkins/config-freestyle-maven.xml").toPath()));
+            assertThat(responseMaven.getBody()).isEqualToIgnoringWhitespace(expectedJobMaven);
         }
 
         @Test

--- a/src/test/java/io/moderne/connect/commands/JenkinsTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsTest.java
@@ -119,7 +119,7 @@ class JenkinsTest {
             jenkins.publishCredsId = "artifactCreds";
             assertPublishSteps("""
                     withCredentials([string(credentialsId: 'modToken', variable: 'MODERNE_TOKEN')]) {
-                        sh 'mod config moderne --token=${MODERNE_TOKEN} https://app.moderne.io'
+                        sh 'mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io'
                     }
                     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactCreds', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
                         sh 'mod config artifacts --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://my.artifactory/moderne-ingest'
@@ -146,7 +146,8 @@ class JenkinsTest {
             jenkins.jobType = Jenkins.JobType.PIPELINE;
             jenkins.mvnPluginVersion = "5.0.2";
             assertPublishSteps("""
-                    sh 'mod build . --no-download --maven-plugin-version 5.0.2'
+                    sh 'mod config maven plugin edit --version 5.0.2'
+                    sh 'mod build . --no-download'
                     sh 'mod publish .'
                     """);
         }
@@ -156,7 +157,8 @@ class JenkinsTest {
             jenkins.jobType = Jenkins.JobType.PIPELINE;
             jenkins.gradlePluginVersion = "5.0.2";
             assertPublishSteps("""
-                    sh 'mod build . --no-download --gradle-plugin-version 5.0.2'
+                    sh 'mod config gradle plugin edit --version 5.0.2'
+                    sh 'mod build . --no-download'
                     sh 'mod publish .'
                     """);
         }
@@ -181,8 +183,8 @@ class JenkinsTest {
         }
 
         void assertPublishSteps(@Language("groovy") String steps) {
-            assertThat(jenkins.createStagePublish("", "", "", ""))
-                    .isEqualToIgnoringWhitespace("stage('Publish') { steps { %s } }".formatted(steps));
+            assertThat(jenkins.createStagePublish("maven", "gradle", "", ""))
+                    .isEqualToIgnoringWhitespace("stage('Publish') { tools { maven 'maven' gradle 'gradle' } steps { %s } }".formatted(steps));
         }
     }
 }

--- a/src/test/jenkins/Dockerfile
+++ b/src/test/jenkins/Dockerfile
@@ -9,11 +9,12 @@ RUN jenkins-plugin-cli --plugins \
     git:5.1.0 \
     git-client:4.4.0 \
     gradle:2.8 \
-    credentials-binding:636.v55f1275c7b_27 \
+    credentials-binding:631.v861c06d062b_4 \
     config-file-provider:953.v0432a_802e4d2 \
     jdk-tool:66.vd8fa_64ee91b_d \
     pipeline-model-definition:2.2121.vd87fb_6536d1e \
-    workflow-cps:3791.va_c0338ea_b_59c \
-    workflow-job:1326.ve643e00e9220 \
+    pipeline-model-extensions:2.2144.v077a_d1928a_40 \
+    workflow-cps:3691.v28b_14c465a_b_b_ \
+    workflow-job:1308.v58d48a_763b_31 \
     ws-cleanup:0.45
 

--- a/src/test/jenkins/config-agent.xml
+++ b/src/test/jenkins/config-agent.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1326.ve643e00e9220">
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
     <actions>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
@@ -29,7 +29,7 @@
             </triggers>
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
-    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3791.va_c0338ea_b_59c">
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
         <script><![CDATA[
         pipeline {
             agent { label 'os=windows && !reserved' }

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -42,12 +42,12 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v1.0.3/moderne-cli-linux-v1.0.3 --fail -o mod;
+            <command>curl --request GET https://pkgs.dev.azure.com/moderneinc/moderne_public/_packaging/moderne/maven/v1/io/moderne/moderne-cli-linux/v1.4.11/moderne-cli-linux-v1.4.11 --fail -o mod;
                 chmod 755 mod;</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne --token=${MODERNE_TOKEN} https://app.moderne.io</command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
@@ -99,7 +99,7 @@ echo "ingest.gradle" >> .git/info/exclude;
         </hudson.tasks.ArtifactArchiver>
     </publishers>
     <buildWrappers>
-        <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@636.v55f1275c7b_27">
+        <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@631.v861c06d062b_4">
             <bindings>
                 <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
                     <credentialsId>artifactCreds</credentialsId>

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -16,7 +16,7 @@
         <configVersion>2</configVersion>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
-                <url>https://github.com/openrewrite/rewrite-spring.git</url>
+                <url>https://github.com/openrewrite/rewrite-maven-plugin.git</url>
                 <credentialsId>myGitCreds</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>
@@ -55,35 +55,49 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
+            <command>./mod config maven plugin edit --version 2.4.2</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
             <command><![CDATA[
 echo "
-  task modBuild(type:Exec) {
-    workingDir '.'
-    commandLine './mod', 'build', '.', '--no-download', '--maven-settings', '${MODERNE_MVN_SETTINGS_XML}'
-  }
-" > ingest.gradle;
-echo "ingest.gradle" >> .git/info/exclude;
+  <project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.moderne</groupId>
+    <artifactId>ingest</artifactId>
+    <version>1.0</version>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <executable>./mod</executable>
+            <arguments><argument>build</argument>
+              <argument>.</argument>
+              <argument>--no-download</argument>
+              <argument>--maven-settings</argument>
+              <argument>${MODERNE_MVN_SETTINGS_XML}</argument></arguments>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+  </project>
+" > ingest.xml;
+echo "ingest.xml" >> .git/info/exclude;
       ]]></command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
-        <hudson.plugins.gradle.Gradle plugin="gradle@2.8">
-            <switches/>
-            <tasks>modBuild</tasks>
-            <rootBuildScriptDir/>
-            <buildFile>ingest.gradle</buildFile>
-            <gradleName>gradle</gradleName>
-            <useWrapper>false</useWrapper>
-            <makeExecutable>false</makeExecutable>
-            <useWorkspaceAsHome>false</useWorkspaceAsHome>
-            <wrapperLocation/>
-            <passAllAsSystemProperties>false</passAllAsSystemProperties>
-            <projectProperties/>
-            <passAllAsProjectProperties>false</passAllAsProjectProperties>
-        </hudson.plugins.gradle.Gradle>
+        <hudson.tasks.Maven>
+            <mavenName>maven</mavenName>
+            <targets>exec:exec</targets>
+            <pom>ingest.xml</pom>
+            <usePrivateRepository>false</usePrivateRepository>
+            <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+            <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+            <injectBuildVariables>false</injectBuildVariables>
+        </hudson.tasks.Maven>
 
         <hudson.tasks.Shell>
             <command>./mod publish .</command>

--- a/src/test/jenkins/config-no-cleanup.xml
+++ b/src/test/jenkins/config-no-cleanup.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1326.ve643e00e9220">
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
     <actions>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
@@ -29,7 +29,7 @@
             </triggers>
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
-    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3791.va_c0338ea_b_59c">
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
         <script><![CDATA[
         pipeline {
             agent any

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1326.ve643e00e9220">
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
     <actions>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
@@ -29,7 +29,7 @@
             </triggers>
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
-    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3791.va_c0338ea_b_59c">
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
         <script><![CDATA[
         pipeline {
             agent any

--- a/src/test/jenkins/rewrite-java-migration-config.xml
+++ b/src/test/jenkins/rewrite-java-migration-config.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1326.ve643e00e9220">
+<?xml version="1.0" encoding="UTF-8"?><flow-definition plugin="workflow-job@1308.v58d48a_763b_31">
     <actions>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e"/>
         <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2121.vd87fb_6536d1e">
@@ -29,7 +29,7 @@
             </triggers>
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
     </properties>
-    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3791.va_c0338ea_b_59c">
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@3691.v28b_14c465a_b_b_">
         <script><![CDATA[
         pipeline {
             agent any


### PR DESCRIPTION
## What's changed?
New version of mod-cli has maven/gradle plugin versions as configs + mirrorUrl

## Anyone you would like to review specifically?
@knutwannheden @timtebeek 

## Any additional context
Reverted some jenkins plugins versions because I've explicitly added the transitive dependency that was causing the change.
Also updated the mod conf moderne *edit* command

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
