### PR TITLE
use env var to config maven settings

### DIFF
--- a/src/test/java/io/moderne/connect/commands/JenkinsIntegTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsIntegTest.java
@@ -130,6 +130,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -173,6 +176,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -192,6 +198,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -212,6 +221,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -231,6 +243,9 @@ class JenkinsIntegTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
+                "--gradlePluginVersion", "2.2.2",
+                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
+                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup",
                 "--deleteSkipped=true");
         assertEquals(0, result);

--- a/src/test/java/io/moderne/connect/commands/JenkinsTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsTest.java
@@ -134,7 +134,7 @@ class JenkinsTest {
             jenkins.jobType = Jenkins.JobType.PIPELINE;
             jenkins.mavenSettingsConfigFileId = "maven-ingest-settings-credentials";
             assertPublishSteps("""
-                    sh 'mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"'
+                    sh 'mod config maven settings edit "\\${MODERNE_MVN_SETTINGS_XML}"'
                     configFileProvider([configFile(fileId: 'maven-ingest-settings-credentials', variable: 'MODERNE_MVN_SETTINGS_XML')]) {
                         sh 'mod build . --no-download'
                     }

--- a/src/test/java/io/moderne/connect/commands/JenkinsTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsTest.java
@@ -134,7 +134,7 @@ class JenkinsTest {
             jenkins.jobType = Jenkins.JobType.PIPELINE;
             jenkins.mavenSettingsConfigFileId = "maven-ingest-settings-credentials";
             assertPublishSteps("""
-                    sh 'mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML}'
+                    sh 'mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"'
                     configFileProvider([configFile(fileId: 'maven-ingest-settings-credentials', variable: 'MODERNE_MVN_SETTINGS_XML')]) {
                         sh 'mod build . --no-download'
                     }

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -55,6 +55,10 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
+            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
             <command><![CDATA[
 echo "
   task modBuild(type:Exec) {

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -59,6 +59,15 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
+            <command>./mod config maven plugin edit --version 2.4.2</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+
+        <hudson.tasks.Shell>
             <command><![CDATA[
 echo "
   task modBuild(type:Exec) {

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -55,13 +55,18 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
+            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
+            <configuredLocalRules/>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
             <command>./mod config maven plugin edit --version 2.4.2</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML}</command>
+            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
+
         <hudson.tasks.Shell>
             <command><![CDATA[
 echo "

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -49,6 +49,8 @@
                         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactCreds', usernameVariable: 'ARTIFACTS_PUBLISH_CRED_USR', passwordVariable: 'ARTIFACTS_PUBLISH_CRED_PWD']]) {
                             sh 'mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest'
                         }
+                        sh 'mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3'
+                        sh 'mod config maven plugin edit --version 2.4.2'
                         sh 'mod build . --no-download'
                         sh 'mod publish .'
                     }


### PR DESCRIPTION
## What's changed?
Use an env-var to configure maven settings
Also reverted that we only configure maven/gradle if the maven/gradle tool is present

## What's your motivation?
This way there is no race condition on configuring different values for the setting

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
