### PR TITLE
Use powershell on Windows OS for commands

### DIFF
--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -309,11 +309,12 @@ public class Jenkins implements Callable<Integer> {
     private static final String GRADLE_PLUGIN = "gradle";
     private static final String CREDENTIALS_PLUGIN = "credentials-binding";
     private static final String CONFIG_FILE_PLUGIN = "config-file-provider";
+    private static final String POWERSHELL_PLUGIN = "powershell";
     private static final Set<String> REQUIRED_PLUGINS = Stream.of(
             CLOUDBEES_FOLDER_PLUGIN, GIT_PLUGIN, CREDENTIALS_PLUGIN
     ).collect(Collectors.toSet());
     private static final Set<String> OPTIONAL_PLUGINS = Stream.of(
-            GRADLE_PLUGIN
+            GRADLE_PLUGIN, POWERSHELL_PLUGIN
     ).collect(Collectors.toSet());
 
     @RequiredArgsConstructor
@@ -321,6 +322,7 @@ public class Jenkins implements Callable<Integer> {
         FREESTYLE_JOB_DEFINITION("cli/jenkins/freestyle_job.xml.template"),
         FREESTYLE_SCM_DEFINITION("cli/jenkins/freestyle_scm.xml.template"),
         FREESTYLE_SHELL_DEFINITION("cli/jenkins/freestyle_shell.xml.template"),
+        FREESTYLE_POWERSHELL_DEFINITION("cli/jenkins/freestyle_powershell.xml.template"),
         FREESTYLE_GRADLE_DEFINITION("cli/jenkins/freestyle_gradle.xml.template"),
         FREESTYLE_MAVEN_DEFINITION("cli/jenkins/freestyle_maven.xml.template"),
         FREESTYLE_CREDENTIALS_DEFINITION("cli/jenkins/freestyle_credentials.xml.template"),
@@ -638,7 +640,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            command += isWindowsPlatform ? ".\\\\" : "./";
+            command += isWindowsPlatform ? ".\\" : "./";
         }
         command += String.format("%s config artifacts edit %s--user=%s --password=%s %s",
                 isWindowsPlatform ? "mod.exe" : "mod",
@@ -658,7 +660,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            command += isWindowsPlatform ? ".\\\\" : "./";
+            command += isWindowsPlatform ? ".\\" : "./";
         }
         command += String.format("%s config moderne edit --token=%s %s",
                 isWindowsPlatform ? "mod.exe" : "mod",
@@ -676,7 +678,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            command += isWindowsPlatform ? ".\\\\" : "./";
+            command += isWindowsPlatform ? ".\\" : "./";
         }
         command += String.format("%s config gradle plugin edit",
                 isWindowsPlatform ? "mod.exe" : "mod");
@@ -699,7 +701,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            command += isWindowsPlatform ? ".\\\\" : "./";
+            command += isWindowsPlatform ? ".\\" : "./";
         }
         return command + String.format("%s config maven plugin edit --version %s",
                 isWindowsPlatform ? "mod.exe" : "mod",
@@ -714,7 +716,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String command = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            command += isWindowsPlatform ? ".\\\\" : "./";
+            command += isWindowsPlatform ? ".\\" : "./";
         }
 
         return command + String.format("%s config maven settings edit %s",
@@ -726,7 +728,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String prefix = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            prefix += isWindowsPlatform ? ".\\\\" : "./";
+            prefix += isWindowsPlatform ? ".\\" : "./";
         }
         String command = String.format("%s%s build . --no-download", prefix, isWindowsPlatform ? "mod.exe" : "mod");
         if (!StringUtils.isBlank(activeStyle)) {
@@ -746,7 +748,7 @@ public class Jenkins implements Callable<Integer> {
         boolean isWindowsPlatform = isWindowsPlatform();
         String prefix = "";
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
-            prefix = isWindowsPlatform ? ".\\\\" : "./";
+            prefix = isWindowsPlatform ? ".\\" : "./";
         }
         return String.format("%s%s publish .", prefix, isWindowsPlatform ? "mod.exe" : "mod");
     }
@@ -764,49 +766,102 @@ public class Jenkins implements Callable<Integer> {
             return "";
         }
         String downloadURL = getDownloadCLIUrl();
-        String credentials = "";
-        if (!StringUtils.isBlank(downloadCLICreds)) {
-            credentials = "--user ${CLI_DOWNLOAD_CRED_USR}:${CLI_DOWNLOAD_CRED_PWD} ";
+
+        boolean isWindowsPlatform = isWindowsPlatform();
+        if (isWindowsPlatform) {
+            String credentials = "";
+            if (StringUtils.isNotBlank(downloadCLICreds)) {
+                credentials = "$wc.Headers[\"Authorization\"] = string.Format(\"Basic {0}\", " +
+                        "Convert.ToBase64String(Encoding.ASCII.GetBytes(\"$env:CLI_DOWNLOAD_CRED_USR\", \"$env:CLI_DOWNLOAD_CRED_PWD\")))";
+            }
+            return String.format(
+                    "$wc = New-Object System.Net.WebClient\n" +
+                    "%s\n" +
+                    "$wc.DownloadFile(\"%s\", \"mod.exe\")",
+                    credentials,
+                    downloadURL);
+        } else {
+            String credentials = "";
+            if (!StringUtils.isBlank(downloadCLICreds)) {
+                credentials = "--user ${CLI_DOWNLOAD_CRED_USR}:${CLI_DOWNLOAD_CRED_PWD} ";
+            }
+            return String.format("curl %s--request GET %s --fail -o mod;\nchmod 755 mod;", credentials, downloadURL);
         }
-        return String.format("curl %s--request GET %s --fail -o mod;\nchmod 755 mod;", credentials, downloadURL);
     }
 
     private String createFreestyleSteps(Map<String, String> plugins, String mavenTool, String gradleTool, String repoStyle, String repoBuildAction, boolean isValidate) {
         StringBuilder builder = new StringBuilder();
 
+        boolean isWindowsPlatform = isWindowsPlatform();
+
         if (isValidate) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(
-                    "curl -o patch.diff --request GET --url $patchDownloadUrl --header \"Authorization: Bearer $MODERNE_TOKEN\" --header \"x-moderne-scmtoken: $SCM_TOKEN\""
-            ));
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format("git apply patch.diff"));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(
+                        plugins.get(POWERSHELL_PLUGIN),
+                        "$wc = New-Object System.Net.WebClient\n" +
+                        "$wc.Headers[\"Authorization\"] = \"Bearer \\$env:MODERNE_TOKEN\"\n" +
+                        "$wc.Headers[\"x-moderne-scmtoken\"] = $env:SCM_TOKEN\n" +
+                        "$wc.DownloadFile(\"$patchDownloadUrl\", \"patch.diff\")"
+                ));
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format("git apply patch.diff"));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(
+                        "curl -o patch.diff --request GET --url $patchDownloadUrl --header \"Authorization: Bearer $MODERNE_TOKEN\" --header \"x-moderne-scmtoken: $SCM_TOKEN\""
+                ));
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format("git apply patch.diff"));
+            }
         }
         String download = createFreestyleDownload();
         if (!StringUtils.isBlank(download)) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(download));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), download));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(download));
+            }
         }
 
         String configTenant = createConfigTenantCommand();
         if (!isValidate && !StringUtils.isBlank(configTenant)) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configTenant));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), configTenant));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configTenant));
+            }
         }
 
         if (!isValidate) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createConfigArtifactsCommand()));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), createConfigArtifactsCommand()));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createConfigArtifactsCommand()));
+            }
         }
 
         String buildCommand = createBuildCommand(repoStyle, repoBuildAction);
 
         String configGradle = createConfigGradleCommand();
         if (!StringUtils.isBlank(configGradle)) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configGradle));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), configGradle));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configGradle));
+            }
         }
         String configMavenPlugin = createConfigMavenPluginCommand();
         if (!StringUtils.isBlank(configMavenPlugin)) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configMavenPlugin));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), configMavenPlugin));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configMavenPlugin));
+            }
         }
         String configMavenSettings = createConfigMavenSettingsCommand();
         if (!StringUtils.isBlank(configMavenSettings)) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configMavenSettings));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), configMavenSettings));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(configMavenSettings));
+            }
         }
 
         if (!StringUtils.isBlank(gradleTool)) {
@@ -833,14 +888,20 @@ public class Jenkins implements Callable<Integer> {
                     mavenTool
             ));
         } else {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(
-                    buildCommand
-            ));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), buildCommand));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(buildCommand));
+            }
         }
         builder.append("\n");
 
         if (!isValidate) {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createPublishCommand()));
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), createPublishCommand()));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createPublishCommand()));
+            }
         }
 
         return builder.toString();

--- a/src/main/resources/cli/jenkins/freestyle_powershell.xml.template
+++ b/src/main/resources/cli/jenkins/freestyle_powershell.xml.template
@@ -1,0 +1,6 @@
+    <hudson.plugins.powershell.PowerShell plugin="powershell@%s">
+      <command>%s</command>
+      <configuredLocalRules/>
+      <useProfile>true</useProfile>
+      <stopOnError>true</stopOnError>
+    </hudson.plugins.powershell.PowerShell>


### PR DESCRIPTION
## What's changed?
The `hudson.steps.Shell` task relies on `nohup` which is unavailable for Windows. 

## What's your motivation?
Enable Moderne Ingest from a Windows host OS.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Another alternative would have been to use the core `hudson.steps.BatchFile` step, but unfortunately Windows does not include any mechanisms within that shell context for downloading files. PowerShell, on the other hand, has the full backing of the .NET framework and as such there is the capability to use the `Invoke-WebRequest` cmdlet or the `System.Net.WebClient` integrations. Here I opted for the `System.Net.WebClient` implementation because there is a bug in older versions of PowerShell where when the desire is to download files using `Invoke-WebRequest` the bytes transferred is severely limited. This constraint is not present with the `System.Net.WebClient` variation.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
