### PR TITLE
fix: set buildName for validate jobs

### DIFF
--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -330,10 +330,9 @@ public class Jenkins implements Callable<Integer> {
         FREESTYLE_CREDENTIALS_BINDING_TOKEN_DEFINITION("cli/jenkins/freestyle_credentials_binding_token.xml.template"),
         FREESTYLE_MAVEN_SETTINGS_DEFINITION("cli/jenkins/freestyle_maven_settings.xml.template"),
         FREESTYLE_CLEANUP_DEFINITION("cli/jenkins/freestyle_cleanup.xml.template"),
-
         FOLDER_DEFINITION("cli/jenkins/jenkins_folder.xml.template"),
-
-        PARAMETERS_VALIDATE("cli/jenkins/validate_parameters.xml.template");
+        PARAMETERS_VALIDATE_DEFINITION("cli/jenkins/validate_parameters.xml.template"),
+        BUILD_NAME_SETTER_VALIDATE_DEFINITION("cli/jenkins/validate_build_name_setter.xml.template");
 
         private final String filename;
 
@@ -484,8 +483,9 @@ public class Jenkins implements Callable<Integer> {
         String credentials = isValidateJob ? createFreestyleValidateCredentials(plugins, gitURL) : createFreestyleCredentials(plugins);
         String configFiles = createFreestyleConfigFiles(plugins);
         String cleanup = createFreestyleCleanup(plugins);
-        String jobParameters = isValidateJob ? Templates.PARAMETERS_VALIDATE.format() : "";
-        return createFreestyleJob(jobParameters, scm, assignedNode, steps, cleanup, credentials, configFiles, isValidateJob);
+        String jobParameters = isValidateJob ? Templates.PARAMETERS_VALIDATE_DEFINITION.format() : "";
+        String buildNameSetter = isValidateJob ? Templates.BUILD_NAME_SETTER_VALIDATE_DEFINITION.format() : "";
+        return createFreestyleJob(jobParameters, scm, assignedNode, steps, cleanup, credentials, configFiles, buildNameSetter, isValidateJob);
     }
 
     private <T extends HttpRequest<T>> T authenticate(T request) {
@@ -957,7 +957,7 @@ public class Jenkins implements Callable<Integer> {
         return "";
     }
 
-    private String createFreestyleJob(String params, String scm, String assignedNode, String steps, String cleanup, String credentials, String configFiles, boolean isValidateJob) {
+    private String createFreestyleJob(String params, String scm, String assignedNode, String steps, String cleanup, String credentials, String configFiles, String buildNameSetter, boolean isValidateJob) {
         return Templates.FREESTYLE_JOB_DEFINITION.format(
                 params,
                 scm,
@@ -966,7 +966,8 @@ public class Jenkins implements Callable<Integer> {
                 steps,
                 cleanup,
                 credentials,
-                configFiles
+                configFiles,
+                buildNameSetter
         );
     }
 

--- a/src/main/resources/cli/jenkins/freestyle_job.xml.template
+++ b/src/main/resources/cli/jenkins/freestyle_job.xml.template
@@ -43,5 +43,6 @@
   <buildWrappers>
 %s
 %s
+%s
   </buildWrappers>
 </project>

--- a/src/main/resources/cli/jenkins/validate_build_name_setter.xml.template
+++ b/src/main/resources/cli/jenkins/validate_build_name_setter.xml.template
@@ -1,0 +1,6 @@
+<org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
+    <template>${buildName}</template>
+    <descriptionTemplate/>
+    <runAtStart>true</runAtStart>
+    <runAtEnd>true</runAtEnd>
+</org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>

--- a/src/test/jenkins/config-freestyle-gradle-validate.xml
+++ b/src/test/jenkins/config-freestyle-gradle-validate.xml
@@ -159,6 +159,11 @@ echo "ingest.gradle" >> .git/info/exclude;
                 </org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
             </managedFiles>
         </org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper>
-
+        <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
+            <template>${buildName}</template>
+            <descriptionTemplate/>
+            <runAtStart>true</runAtStart>
+            <runAtEnd>true</runAtEnd>
+        </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
     </buildWrappers>
 </project>

--- a/src/test/jenkins/config-freestyle-maven-validate.xml
+++ b/src/test/jenkins/config-freestyle-maven-validate.xml
@@ -172,6 +172,11 @@ echo "ingest.xml" >> .git/info/exclude;
                 </org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile>
             </managedFiles>
         </org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper>
-
+        <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@2.2.0">
+            <template>${buildName}</template>
+            <descriptionTemplate/>
+            <runAtStart>true</runAtStart>
+            <runAtEnd>true</runAtEnd>
+        </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
     </buildWrappers>
 </project>


### PR DESCRIPTION
## What's changed?
Adds build name setter to set build name for validate jobs. 

## What's your motivation?
Validate jobs supply a buildName parameter that is used to lookup the job for status updates. 
This was lost when moved from pipeline to freestyle syntax.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- [X] I've updated the documentation (if applicable)
