### PR TITLE
removed deprecated parameters

### DIFF
--- a/src/test/java/io/moderne/connect/commands/JenkinsTest.java
+++ b/src/test/java/io/moderne/connect/commands/JenkinsTest.java
@@ -105,9 +105,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup",
                 "--verbose");
         assertEquals(0, result);
@@ -131,9 +128,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -177,9 +171,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -199,9 +190,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -222,9 +210,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup");
         assertEquals(0, result);
 
@@ -244,9 +229,6 @@ class JenkinsTest {
                 "--publishCredsId", ARTIFACT_CREDS,
                 "--gitCredsId", GIT_CREDS,
                 "--publishUrl", ARTIFACTORY_URL,
-                "--gradlePluginVersion", "2.2.2",
-                "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                "--mvnPluginVersion", "2.4.2",
                 "--workspaceCleanup",
                 "--deleteSkipped=true");
         assertEquals(0, result);
@@ -317,9 +299,6 @@ class JenkinsTest {
                     "--moderneUrl=" + MODERNE_URL,
                     "--moderneToken=" + MODERNE_TOKEN,
                     "--workspaceCleanup",
-                    "--gradlePluginVersion", "2.2.2",
-                    "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                    "--mvnPluginVersion", "2.4.2",
                     "--verbose");
             assertEquals(0, result);
 
@@ -358,9 +337,6 @@ class JenkinsTest {
                     "--moderneToken=" + MODERNE_TOKEN,
                     "--createValidateJobs",
                     "--workspaceCleanup",
-                    "--gradlePluginVersion", "2.2.2",
-                    "--mirrorUrl", "http://artifactory.moderne.internal/artifactory/moderne-cache-3",
-                    "--mvnPluginVersion", "2.4.2",
                     "--verbose");
             assertEquals(0, result);
 

--- a/src/test/jenkins/config-freestyle-gradle-validate.xml
+++ b/src/test/jenkins/config-freestyle-gradle-validate.xml
@@ -70,14 +70,6 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-            <command>./mod config maven plugin edit --version 2.4.2</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
             <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -55,14 +55,6 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-            <command>./mod config maven plugin edit --version 2.4.2</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
             <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-maven-validate.xml
+++ b/src/test/jenkins/config-freestyle-maven-validate.xml
@@ -70,14 +70,6 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-            <command>./mod config maven plugin edit --version 2.4.2</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
             <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -55,14 +55,6 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-            <command>./mod config maven plugin edit --version 2.4.2</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
             <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -47,14 +47,6 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>mod config gradle plugin edit --version 2.2.2 --repository-url http://artifactory.moderne.internal/artifactory/moderne-cache-3</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-            <command>mod config maven plugin edit --version 2.4.2</command>
-            <configuredLocalRules/>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
             <command>mod build . --no-download</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>


### PR DESCRIPTION
## What's changed?
removed deprecated configs from mod-cli:
- mirrorUrl
- gradlePluginVersion
- mavenPluginVersion

## What's your motivation?
Those configs are no longer available on mod-cli 1.7.0+

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
