### PR TITLE
change to local configs

### DIFF
--- a/src/main/java/io/moderne/connect/commands/GitLab.java
+++ b/src/main/java/io/moderne/connect/commands/GitLab.java
@@ -472,7 +472,7 @@ public class GitLab implements Callable<Integer> {
             return ""; // for unit tests, will always be non-null in production
         }
         String args = String.format("config artifacts edit %s--user=%s --password=%s %s",
-                skipSSL ? "--skipSSL " : "",
+                skipSSL ? "--skip-ssl " : "",
                 variable(publishUserSecretName),
                 variable(publishPwdSecretName),
                 publishUrl

--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -620,9 +620,9 @@ public class Jenkins implements Callable<Integer> {
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
             command += isWindowsPlatform ? ".\\" : "./";
         }
-        command += String.format("%s config artifacts edit %s--user=%s --password=%s %s",
+        command += String.format("%s config artifacts edit %s--user=%s --password=%s %s --local .",
                 isWindowsPlatform ? "mod.exe" : "mod",
-                skipSSL ? "--skipSSL " : "",
+                skipSSL ? "--skip-ssl " : "",
                 isWindowsPlatform ? "$env:ARTIFACTS_PUBLISH_CRED_USR" : "${ARTIFACTS_PUBLISH_CRED_USR}",
                 isWindowsPlatform ? "$env:ARTIFACTS_PUBLISH_CRED_PWD" : "${ARTIFACTS_PUBLISH_CRED_PWD}",
                 publishUrl
@@ -640,7 +640,7 @@ public class Jenkins implements Callable<Integer> {
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
             command += isWindowsPlatform ? ".\\" : "./";
         }
-        command += String.format("%s config moderne edit --token=%s %s",
+        command += String.format("%s config moderne edit --token=%s %s --local .",
                 isWindowsPlatform ? "mod.exe" : "mod",
                 isWindowsPlatform ? "$env:MODERNE_TOKEN" : "${MODERNE_TOKEN}",
                 tenant.moderneUrl
@@ -659,9 +659,9 @@ public class Jenkins implements Callable<Integer> {
             command += isWindowsPlatform ? ".\\" : "./";
         }
 
-        return command + String.format("%s config maven settings edit %s",
+        return command + String.format("%s config maven settings edit %s --local .",
                 isWindowsPlatform ? "mod.exe" : "mod",
-                isWindowsPlatform ? "\"\\$env:MODERNE_MVN_SETTINGS_XML\"" : "\"\\${MODERNE_MVN_SETTINGS_XML}\"");
+                isWindowsPlatform ? "$env:MODERNE_MVN_SETTINGS_XML" : "${MODERNE_MVN_SETTINGS_XML}");
     }
 
     private String createBuildCommand(String activeStyle, String additionalBuildArgs) {

--- a/src/test/java/io/moderne/connect/commands/GitlabTest.java
+++ b/src/test/java/io/moderne/connect/commands/GitlabTest.java
@@ -167,7 +167,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             gitlab.skipSSL = true;
             assertBuildSteps(
-                    "./mod config artifacts edit --skipSSL --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config artifacts edit --skip-ssl --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download --active-styles some-style --additional-build-args \"--magic\"",
                     "./mod publish $REPO_PATH"
             );

--- a/src/test/jenkins/config-agent.xml
+++ b/src/test/jenkins/config-agent.xml
@@ -44,7 +44,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -47,15 +47,15 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io</command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML} --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle-validate.xml
+++ b/src/test/jenkins/config-freestyle-gradle-validate.xml
@@ -70,7 +70,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML} --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -47,15 +47,15 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io</command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML} --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
 

--- a/src/test/jenkins/config-freestyle-maven-validate.xml
+++ b/src/test/jenkins/config-freestyle-maven-validate.xml
@@ -70,7 +70,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML} --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -47,15 +47,15 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io</command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>./mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config maven settings edit "\${MODERNE_MVN_SETTINGS_XML}"</command>
+            <command>./mod config maven settings edit ${MODERNE_MVN_SETTINGS_XML} --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
 

--- a/src/test/jenkins/config-no-cleanup.xml
+++ b/src/test/jenkins/config-no-cleanup.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/rewrite-java-migration-config.xml
+++ b/src/test/jenkins/rewrite-java-migration-config.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest</command>
+            <command>mod config artifacts edit --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest --local .</command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>


### PR DESCRIPTION
## What's changed?
Changed all configs to local configs.
Also, no longer need to use the workaround of configuring the maven settings file with the env variable substitution.
Fixed the `--skipSSL` -> `--skip-ssl` parameter too on Jenkins and GitLab

## What's your motivation?
It makes sense that all configs are local, since we are configuring them on each job, and on a multi-tenant environment those could be different per job. So better to configure them on the workspace rather than on the home of each worker.

## Anyone you would like to review specifically?
@timtebeek 
