### PR TITLE
Drop download CLI option

### DIFF
--- a/src/main/java/io/moderne/connect/commands/GitHub.java
+++ b/src/main/java/io/moderne/connect/commands/GitHub.java
@@ -219,11 +219,11 @@ public class GitHub implements Callable<Integer> {
                     "@|bold Example|@: -Dmaven.antrun.skip=true\n")
     private String additionalBuildArgs;
 
-    @CommandLine.Option(names = "--cliVersion", defaultValue = "v1.0.3",
+    @CommandLine.Option(names = "--cliVersion", defaultValue = "v2.0.5",
             description = "The version of the Moderne CLI that should be used when running the ingestion workflow. " +
                     "Follows standard semantic versioning with a v in front.\n" +
                     "\n" +
-                    "@|bold Example|@: @|bold v0.0.50|@\n")
+                    "@|bold Example|@: @|bold v2.0.5|@\n")
     private String cliVersion;
 
     @CommandLine.Option(names = "--dispatchSecretName",

--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -332,8 +332,8 @@ public class Jenkins implements Callable<Integer> {
             return 1;
         }
 
-        if (!cliVersion.startsWith("v0.4") && !cliVersion.startsWith("v0.5") && !cliVersion.startsWith("v1")) {
-            System.err.println("Unsupported CLI version: " + cliVersion + ". Please use a version greater than v0.4");
+        if (!cliVersion.startsWith("v2")) {
+            System.err.println("Unsupported CLI version: " + cliVersion + ". Please use a version greater than v2");
             return 1;
         }
 

--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -155,7 +155,7 @@ public class Jenkins implements Callable<Integer> {
             description = "An expression to match the Jenkins agent that will run the job.\n")
     String agent;
 
-    @CommandLine.Option(names = "--cliVersion", defaultValue = "v1.4.11",
+    @CommandLine.Option(names = "--cliVersion", defaultValue = "v2.0.5",
             description = "The version of the Moderne CLI that should be used when running Jenkins Jobs.\n")
     String cliVersion;
 

--- a/src/main/java/io/moderne/connect/utils/GitLabYaml.java
+++ b/src/main/java/io/moderne/connect/utils/GitLabYaml.java
@@ -35,10 +35,6 @@ import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.SPLIT_
 public class GitLabYaml {
 
     public enum Stage {
-
-        @JsonProperty("download")
-        DOWNLOAD,
-
         @JsonProperty("build-lst")
         BUILD_LST
     }
@@ -65,15 +61,12 @@ public class GitLabYaml {
 
         @Singular
         List<Stage> stages;
-        Job download;
-
         @Singular
         Map<String, Job> jobs;
 
         Map<String, Object> prepareYamlMap() {
             Map<String, Object> pipeline = new LinkedHashMap<>();
             pipeline.put("stages", stages);
-            pipeline.put("download", download);
             pipeline.putAll(jobs);
             return pipeline;
         }

--- a/src/test/java/io/moderne/connect/utils/GitLabYamlTest.java
+++ b/src/test/java/io/moderne/connect/utils/GitLabYamlTest.java
@@ -26,18 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GitLabYamlTest {
     @Test
     void writePipelineYaml() {
-        GitLabYaml.Job download = GitLabYaml.Job.builder()
-                .cache(GitLabYaml.Cache.builder().key("cli-v4.4.0")
-                        .paths(List.of("mod"))
-                        .policy(GitLabYaml.Cache.Policy.PUSH_AND_PULL)
-                        .build())
-                .stage(GitLabYaml.Stage.DOWNLOAD)
-                .tags(List.of("docker"))
-                .variables(Map.of("GITLAB_HOST", "gitlab.com"))
-                .command("echo \"download CLI if not exists\"")
-                .build();
-
-
         GitLabYaml.Job job = GitLabYaml.Job.builder()
                 .cache(GitLabYaml.Cache.builder().key("key")
                         .paths(List.of("a", "b"))
@@ -52,8 +40,6 @@ class GitLabYamlTest {
 
 
         GitLabYaml.Pipeline pipeline = GitLabYaml.Pipeline.builder()
-                .stage(GitLabYaml.Stage.DOWNLOAD)
-                .download(download)
                 .stage(GitLabYaml.Stage.BUILD_LST)
                 .job("build-a", job)
                 .job("build-b", job)
@@ -64,23 +50,7 @@ class GitLabYamlTest {
         //language=yaml
         String expected = """
                 stages:
-                - download
                 - build-lst
-                download:
-                  cache:
-                    key: cli-v4.4.0
-                    paths:
-                    - mod
-                    policy: pull-push
-                  stage: download
-                  tags:
-                  - docker
-                  variables:
-                    GITLAB_HOST: gitlab.com
-                  before_script: []
-                  script:
-                  - echo "download CLI if not exists"
-                  retry: 0
                 build-a:
                   image: ruby:latest
                   cache:


### PR DESCRIPTION
The options to download the CLI unnecessarily pinned the version to v1.0.3, whereas for GitLab we already provide `mod` in the image. Drop the download options for GitLab, and bump the version for Jenkins and GitLab.