### PR TITLE
Reintroduce support for configuring an explicit JDK version

### DIFF
--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -790,10 +790,12 @@ public class Jenkins implements Callable<Integer> {
             }
         }
 
-        if (isWindowsPlatform) {
-            builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), createConfigJavaCommand(jdkTool)));
-        } else {
-            builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createConfigJavaCommand(jdkTool)));
+        if (!StringUtils.isBlank(jdkTool)) {
+            if (isWindowsPlatform) {
+                builder.append(Templates.FREESTYLE_POWERSHELL_DEFINITION.format(plugins.get(POWERSHELL_PLUGIN), createConfigJavaCommand(jdkTool)));
+            } else {
+                builder.append(Templates.FREESTYLE_SHELL_DEFINITION.format(createConfigJavaCommand(jdkTool)));
+            }
         }
 
         String buildCommand = createBuildCommand();

--- a/src/test/java/io/moderne/connect/commands/ConnectTest.java
+++ b/src/test/java/io/moderne/connect/commands/ConnectTest.java
@@ -33,6 +33,7 @@ class ConnectTest {
         sw = new StringWriter();
         cmd.setOut(new PrintWriter(sw));
         cmd.setErr(new PrintWriter(sw));
+        cmd.setColorScheme(new CommandLine.Help.ColorScheme.Builder(CommandLine.Help.Ansi.OFF).build());
     }
 
     @Test

--- a/src/test/java/io/moderne/connect/commands/VersionTest.java
+++ b/src/test/java/io/moderne/connect/commands/VersionTest.java
@@ -32,6 +32,6 @@ public class VersionTest {
         cmd.setOut(new PrintWriter(sw));
         cmd.setErr(new PrintWriter(sw));
         assertEquals(0, cmd.execute("version"));
-        assertEquals("development\n", sw.toString());
+        assertEquals("development" + System.lineSeparator(), sw.toString());
     }
 }


### PR DESCRIPTION
## What's changed?
Begin using the `jdkTool` column from the CSV file again.

## What's your motivation?
There are times at which autodetection is unable to determine the correct version, so allow the capability to be explicit under those circumstances. The default expectation is that the column would be left blank resulting in the `mod` CLI autodetection being used. This then provides an escape hatch to only be used when the autodetection is insufficient.

## Have you considered any alternatives or workarounds?
Take control of Jenkins job configuration fully.

### Checklist
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
