### PR TITLE
Switch to `mod config lsts artifacts` following deprecation

### DIFF
--- a/src/main/java/io/moderne/connect/commands/GitLab.java
+++ b/src/main/java/io/moderne/connect/commands/GitLab.java
@@ -447,7 +447,7 @@ public class GitLab implements Callable<Integer> {
         if (publishUrl == null) {
             return ""; // for unit tests, will always be non-null in production
         }
-        String args = String.format("config artifacts artifactory edit --local=$REPO_PATH %s--user=%s --password=%s %s",
+        String args = String.format("config lsts artifacts artifactory edit --local=$REPO_PATH %s--user=%s --password=%s %s",
                 skipSSL ? "--skip-ssl " : "",
                 variable(publishUserSecretName),
                 variable(publishPwdSecretName),

--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -626,7 +626,7 @@ public class Jenkins implements Callable<Integer> {
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
             command += isWindowsPlatform ? ".\\" : "./";
         }
-        command += String.format("%s config artifacts artifactory edit --local=. %s--user=%s --password=%s %s ",
+        command += String.format("%s config lsts artifacts artifactory edit --local=. %s--user=%s --password=%s %s ",
                 isWindowsPlatform ? "mod.exe" : "mod",
                 skipSSL ? "--skip-ssl " : "",
                 isWindowsPlatform ? "$env:ARTIFACTS_PUBLISH_CRED_USR" : "${ARTIFACTS_PUBLISH_CRED_USR}",

--- a/src/test/java/io/moderne/connect/commands/GitlabTest.java
+++ b/src/test/java/io/moderne/connect/commands/GitlabTest.java
@@ -155,7 +155,7 @@ class GitlabTest {
             gitlab.publishUrl = "https://my.artifactory/moderne-ingest";
             gitlab.publishPwdSecretName = "PUBLISH_SECRET";
             gitlab.publishUserSecretName = "PUBLISH_USER";
-            assertBuildSteps(".\\\\mod.exe config artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+            assertBuildSteps(".\\\\mod.exe config lsts artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     ".\\\\mod.exe build $REPO_PATH --no-download",
                     ".\\\\mod.exe publish $REPO_PATH");
         }
@@ -167,7 +167,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             gitlab.skipSSL = true;
             assertBuildSteps(
-                    "./mod config artifacts artifactory edit --local=$REPO_PATH --skip-ssl --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config lsts artifacts artifactory edit --local=$REPO_PATH --skip-ssl --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download",
                     "./mod publish $REPO_PATH"
             );
@@ -183,7 +183,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
                     "./mod config moderne --token=modToken https://app.moderne.io",
-                    "./mod config artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config lsts artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download",
                     "./mod publish $REPO_PATH"
             );
@@ -198,7 +198,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
                     "./mod config moderne --token=${MODERNE_TOKEN} https://app.moderne.io",
-                    "./mod config artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config lsts artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download",
                     "./mod publish $REPO_PATH"
             );
@@ -214,7 +214,7 @@ class GitlabTest {
             gitlab.publishUserSecretName = "PUBLISH_USER";
             assertBuildSteps(
                     "./mod config moderne --token=$SECRET https://app.moderne.io",
-                    "./mod config artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
+                    "./mod config lsts artifacts artifactory edit --local=$REPO_PATH --user=$PUBLISH_USER --password=$PUBLISH_SECRET https://my.artifactory/moderne-ingest",
                     "./mod build $REPO_PATH --no-download",
                     "./mod publish $REPO_PATH"
             );

--- a/src/test/jenkins/Dockerfile
+++ b/src/test/jenkins/Dockerfile
@@ -5,7 +5,7 @@ COPY casc.yaml /var/jenkins_home/casc.yaml
 RUN jenkins-plugin-cli --plugins \
     adoptopenjdk:1.5 \
     cloudbees-folder:6.815.v0dd5a_cb_40e0e \
-    configuration-as-code:1647.ve39ca_b_829b_42 \
+    configuration-as-code:1670.v564dc8b_982d0 \
     git:5.1.0 \
     git-client:4.4.0 \
     gradle:2.8 \

--- a/src/test/jenkins/config-agent.xml
+++ b/src/test/jenkins/config-agent.xml
@@ -44,7 +44,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-credentials.xml
+++ b/src/test/jenkins/config-credentials.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -51,7 +51,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>./mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -51,7 +51,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>./mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -51,7 +51,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>./mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-no-cleanup.xml
+++ b/src/test/jenkins/config-no-cleanup.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config.xml
+++ b/src/test/jenkins/config.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/rewrite-java-migration-config.xml
+++ b/src/test/jenkins/rewrite-java-migration-config.xml
@@ -43,7 +43,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <hudson.tasks.Shell>
-            <command>mod config artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
+            <command>mod config lsts artifacts artifactory edit --local=. --user=${ARTIFACTS_PUBLISH_CRED_USR} --password=${ARTIFACTS_PUBLISH_CRED_PWD} https://artifactory.moderne.ninja/artifactory/moderne-ingest </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>


### PR DESCRIPTION
As requested; thanks for pointing this out! Just keep in mind that we'd like to nudge folks towards our bulk ingestion Docker image to move away from CI integrations, so at some point we might turn this project over to the community.