### PR TITLE
`mod config moderne edit` no longer supports `--local=.`

### DIFF
--- a/src/main/java/io/moderne/connect/commands/Jenkins.java
+++ b/src/main/java/io/moderne/connect/commands/Jenkins.java
@@ -659,7 +659,7 @@ public class Jenkins implements Callable<Integer> {
         if (downloadCLI || !StringUtils.isBlank(downloadCLIUrl)) {
             command += isWindowsPlatform ? ".\\" : "./";
         }
-        command += String.format("%s config moderne edit --local=. --token=%s %s ",
+        command += String.format("%s config moderne edit --token=%s %s ",
                 isWindowsPlatform ? "mod.exe" : "mod",
                 isWindowsPlatform ? "$env:MODERNE_TOKEN" : "${MODERNE_TOKEN}",
                 tenant.moderneUrl

--- a/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
+++ b/src/test/jenkins/config-freestyle-gradle-no-cleanup.xml
@@ -47,7 +47,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --local=. --token=${MODERNE_TOKEN} https://app.moderne.io </command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-gradle.xml
+++ b/src/test/jenkins/config-freestyle-gradle.xml
@@ -47,7 +47,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --local=. --token=${MODERNE_TOKEN} https://app.moderne.io </command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>

--- a/src/test/jenkins/config-freestyle-maven.xml
+++ b/src/test/jenkins/config-freestyle-maven.xml
@@ -47,7 +47,7 @@
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
-            <command>./mod config moderne edit --local=. --token=${MODERNE_TOKEN} https://app.moderne.io </command>
+            <command>./mod config moderne edit --token=${MODERNE_TOKEN} https://app.moderne.io </command>
             <configuredLocalRules/>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>


### PR DESCRIPTION
## What's changed?
Drop `--local=.` from `mod config moderne edit --token`

## What's your motivation?
No longer available in CLI v3.3.2